### PR TITLE
AXLE-53 fixed nuget client

### DIFF
--- a/src/Axle.Client/Axle.Client.csproj
+++ b/src/Axle.Client/Axle.Client.csproj
@@ -15,7 +15,11 @@
     <NoWarn>1701;1702;1705;CA2007</NoWarn>
     <UserSecretsId>25692E6B-C123-474C-A44B-6B2C93BCF65D</UserSecretsId>
     <AssemblyName>Axle.Client</AssemblyName>
-    <Version>0.0.2-developer</Version>
+    <Version>0.0.2</Version>
+    <Authors>Axle Contributors</Authors>
+    <Copyright>Copyright (c) Donut Contributers. All rights reserved.</Copyright>
+    <Company>Lykke</Company>
+    <Product>Axle</Product>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
@@ -29,10 +33,6 @@
 
   <ItemGroup>
     <AdditionalFiles Include="../stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Axle.Dto\Axle.Dto.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Axle.Client/IAxleClient.cs
+++ b/src/Axle.Client/IAxleClient.cs
@@ -3,7 +3,7 @@
 
 namespace Axle.Client
 {
-    using Axle.Dto;
+    using Axle.Client.Models;
     using JetBrains.Annotations;
     using Refit;
     using System.Threading.Tasks;

--- a/src/Axle.Client/Models/UserSessionResponse.cs
+++ b/src/Axle.Client/Models/UserSessionResponse.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Lykke Corp.
+// See the LICENSE file in the project root for more information.
+
+namespace Axle.Client.Models
+{
+    public class UserSessionResponse
+    {
+        public int UserSessionId { get; set; }
+    }
+}


### PR DESCRIPTION
Kept the dto as part of the client project to make.
It was dependent upon Axle.Dto project and it was failing to install because Axle.Dto was expected to be a nuget package.