### PR TITLE
LT-1086 remove coupling with nova_mobile client configuration by addi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 * LT-1120: Fixed warnings for packages version and misusage, which also led to app crash in first web request
 * LT-1086: Exposed endpoint to manually publish login activity (only for mobile clients)
 
+### Configuration changes:
+
+  - Added `axle_api:mobile` scope to `axle_api`. Run following commands on bouncer console to remove and recreate `axle_api` api
+
+```cmd
+auth apis remove axle_api -v
+
+auth apis add axle_api secret -d "Session Management API (AXLE)" -c name -c role -c username -a axle_api -a axle_api:server -a axle_api:mobile -v
+```
+
 ## 2.11.0 (March 8, 2019)
 
 * LT-907: Removing private nuget sources from Nuget.config

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Configure Ironclad by running following commands on console app of Ironclad.
 The api is required to start the axle. Axle will use this api for introspection of reference token passed in the header when some client will call the secure endpoints of axle.
 
 ```
-auth apis add axle_api secret -d "Session Management API (AXLE)" -c name -c role -c username -a axle_api -a axle_api:server -v
+auth apis add axle_api secret -d "Session Management API (AXLE)" -c name -c role -c username -a axle_api -a axle_api:server -a axle_api:mobile -v
 ```
 
 ### clients
@@ -25,7 +25,7 @@ The client is required for sample single page application. Run the following com
 auth clients add website axle_spa -n "Axle Single Page Application" -c http://localhost:5013 -c http://127.0.0.1:5013 -r http://localhost:5013/callback.html -r http://127.0.0.1:5013/callback.html -l http://localhost:5013/index.html -l http://127.0.0.1:5013/index.html -a openid -a profile -a role -a axle_api -t Reference -g implicit -b -q -k -v
 
 -- This is required only for swagger ui
-auth clients add website axle_api_swagger -n "Swagger for Session Management (Axle)" -c http://localhost:5012 -c https://localhost:5120 -c http://127.0.0.1:5012 -c https://127.0.0.1:5120 -c http://axle.mt.svc.cluster.local:5012 -c https://axle.mt.svc.cluster.local:5120 -r http://axle.mt.svc.cluster.local:5012/swagger/oauth2-redirect.html -r https://axle.mt.svc.cluster.local:5120/swagger/oauth2-redirect.html -r http://localhost:5012/swagger/oauth2-redirect.html -r https://localhost:5120/swagger/oauth2-redirect.html -r http://127.0.0.1:5012/swagger/oauth2-redirect.html -r https://127.0.0.1:5120/swagger/oauth2-redirect.html  -a openid -a profile -a axle_api -a axle_api:server -q -b -k -v
+auth clients add website axle_api_swagger -n "Swagger for Session Management (Axle)" -c http://localhost:5012 -c https://localhost:5120 -c http://127.0.0.1:5012 -c https://127.0.0.1:5120 -c http://axle.mt.svc.cluster.local:5012 -c https://axle.mt.svc.cluster.local:5120 -r http://axle.mt.svc.cluster.local:5012/swagger/oauth2-redirect.html -r https://axle.mt.svc.cluster.local:5120/swagger/oauth2-redirect.html -r http://localhost:5012/swagger/oauth2-redirect.html -r https://localhost:5120/swagger/oauth2-redirect.html -r http://127.0.0.1:5012/swagger/oauth2-redirect.html -r https://127.0.0.1:5120/swagger/oauth2-redirect.html  -a openid -a profile -a axle_api -a axle_api:server -a axle_api:mobile -q -b -k -v
 ```
 
 ## How to configure

--- a/src/Axle/Authorization/MobileClientAndAccountOwnerHandler.cs
+++ b/src/Axle/Authorization/MobileClientAndAccountOwnerHandler.cs
@@ -24,7 +24,7 @@ namespace Axle.Authorization
             var routeData = this.contextAccessor.HttpContext.GetRouteData();
             var accountId = routeData.Values["accountId"]?.ToString();
 
-            var isMobileClient = context.User.HasClaim(JwtClaimTypes.ClientId, "nova_mobile");
+            var isMobileClient = context.User.HasClaim(JwtClaimTypes.ClientId, "axle_api:mobile");
 
             var isAccountOwner = context.User.HasClaim(AuthorizationClaims.Accounts, accountId);
 

--- a/src/Axle/Configurators/SwaggerConfigurator.cs
+++ b/src/Axle/Configurators/SwaggerConfigurator.cs
@@ -40,7 +40,8 @@ namespace Axle.Configurators
                     Scopes = new Dictionary<string, string>
                     {
                         { apiName, "CFD Platform (Nova)" },
-                        { $"{apiName}:server", "CFD Platform (Nova) server side methods" }
+                        { $"{apiName}:server", "CFD Platform (Nova) server side methods" },
+                        { $"{apiName}:mobile", "CFD Platform (Nova) mobile side methods" }
                     }
                 };
 


### PR DESCRIPTION
During testing I realized that using nova_mobile client name in axle code is a bad idea, which introduce coupling of mobile client configuration in axle, therefore introduced new scope in `axle_api` api configuration
LT-1086 remove coupling with nova_mobile client configuration by adding axle_api:mobile scope