### PR TITLE
LT-1193 and LT-1210 startup improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 * CONGA-4: Implement Login Error Messages
 * LT-1120: Fixed warnings for packages version and misusage, which also led to app crash in first web request
 * LT-1086: Exposed endpoint to manually publish login activity (only for mobile clients)
+* LT-1193: Validate api authority url and tested api/isAlive endpoint. Thrown proper error message on failure
+* LT-1210: Removed wrong error message when secrets provided from appsettings.json instead of user secrets
+
+### Lykke.Snow.Common.Startup
+
+Lykke.Snow.Common.Startup was updated and a new nuget version is published (Version 1.2.6)
+
+Missing secret wrong error message is removed and a few more improvements made while adding environment variables and secrets
 
 ### Configuration changes:
 

--- a/src/Axle/Axle.csproj
+++ b/src/Axle/Axle.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Lykke.MarginTrading.AccountsManagement.Contracts" Version="1.12.1" />
     <PackageReference Include="Lykke.Middlewares" Version="2.0.0-1550072344" />
     <PackageReference Include="Lykke.RabbitMqBroker" Version="7.8.1" />
-    <PackageReference Include="Lykke.Snow.Common.Startup" Version="1.2.4" />
+    <PackageReference Include="Lykke.Snow.Common.Startup" Version="1.2.6" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2">

--- a/src/Axle/Program.cs
+++ b/src/Axle/Program.cs
@@ -42,11 +42,11 @@ namespace Axle
             // LINK (Cameron): https://github.com/aspnet/KestrelHttpServer/issues/1334
             var environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
             var configuration = new ConfigurationBuilder()
-                .AddEnvironmentSecrets<Startup>(EnvironmentSecretConfig)
                 .AddJsonFile("appsettings.json")
                 .AddJsonFile($"appsettings.Custom.json", optional: true)
                 .AddJsonFile($"appsettings.{environmentName}.json", optional: true)
                 .AddEnvironmentVariables()
+                .AddEnvironmentSecrets<Startup>(EnvironmentSecretConfig)
                 .AddCommandLine(args)
                 .Build();
 

--- a/src/Axle/Settings/AppSettings.cs
+++ b/src/Axle/Settings/AppSettings.cs
@@ -8,6 +8,9 @@ namespace Axle.Settings
     public class AppSettings
     {
         [HttpCheck("api/isalive")]
+        public string ApiAuthority { get; set; }
+
+        [HttpCheck("api/isalive")]
         public string chestUrl { get; set; }
 
         [HttpCheck("api/isalive")]

--- a/src/Tests/Axle.Tests.Acceptance/Axle.Tests.Acceptance.csproj
+++ b/src/Tests/Axle.Tests.Acceptance/Axle.Tests.Acceptance.csproj
@@ -26,8 +26,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
     <PackageReference Include="Xbehave" Version="2.3.0" />


### PR DESCRIPTION
LT-1193 validate api authority url and api/isAlive endpoint
LT-1210: Removed wrong error message when secrets provided from appsettings.json instead of user secrets