### PR TITLE
Axle 59 one tab restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## UNRELEASED
 
 * AXLE-61: Modified storage to keep investor sessions per account
-* Axle-62: Added hub method for logging out
+* AXLE-62: Added hub method for logging out
+* AXLE-59: Allow only one tab to be open by a given user
 
 ## 2.13.0 (April 10, 2019)
 

--- a/src/Axle.Dto/TerminateConnectionReason.cs
+++ b/src/Axle.Dto/TerminateConnectionReason.cs
@@ -1,0 +1,11 @@
+﻿// (c) Lykke Corporation 2019 - All rights reserved. No copying, adaptation, decompiling, distribution or any other form of use permitted.
+
+namespace Axle.Dto
+{
+    public enum TerminateConnectionReason
+    {
+        Other,
+        DifferentDevice,
+        DifferentTab
+    }
+}

--- a/src/Axle.Dto/TerminateOtherTabsNotification.cs
+++ b/src/Axle.Dto/TerminateOtherTabsNotification.cs
@@ -1,0 +1,20 @@
+﻿// (c) Lykke Corporation 2019 - All rights reserved. No copying, adaptation, decompiling, distribution or any other form of use permitted.
+
+
+namespace Axle.Dto
+{
+    using MessagePack;
+
+    [MessagePackObject]
+    public class TerminateOtherTabsNotification
+    {
+        [Key(0)]
+        public string OriginatingServiceId { get; set; }
+
+        [Key(1)]
+        public string OriginatingConnectionId { get; set; }
+
+        [Key(2)]
+        public string AccessToken { get; set; }
+    }
+}

--- a/src/Axle.Persistence/Axle.Persistence.csproj
+++ b/src/Axle.Persistence/Axle.Persistence.csproj
@@ -9,6 +9,7 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <TrimUnusedDependencies>true</TrimUnusedDependencies>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Axle.Persistence/IReadOnlyRepository{TId,TEntity}.cs
+++ b/src/Axle.Persistence/IReadOnlyRepository{TId,TEntity}.cs
@@ -2,11 +2,18 @@
 
 namespace Axle.Persistence
 {
+    using System;
     using System.Collections.Generic;
 
     public interface IReadOnlyRepository<TId, TEntity>
     {
 #pragma warning disable CA1716 // Identifiers should not match keywords
         TEntity Get(TId id);
+
+        bool TryGet(TId id, out TEntity entity);
+
+        IReadOnlyList<KeyValuePair<TId, TEntity>> GetAll();
+
+        IEnumerable<KeyValuePair<TId, TEntity>> Find(Func<TEntity, bool> filter);
     }
 }

--- a/src/Axle.Persistence/ISessionRepository.cs
+++ b/src/Axle.Persistence/ISessionRepository.cs
@@ -19,7 +19,7 @@ namespace Axle.Persistence
 
         void Remove(int sessionId, string userName, string accountId);
 
-        void RefreshSessionTimeouts(IEnumerable<Session> sessions);
+        void RefreshSessionTimeouts(IEnumerable<int> sessions);
 
         IEnumerable<Session> GetExpiredSessions();
     }

--- a/src/Axle.Persistence/InMemoryRepository{TId,TEntity}.cs
+++ b/src/Axle.Persistence/InMemoryRepository{TId,TEntity}.cs
@@ -2,7 +2,10 @@
 
 namespace Axle.Persistence
 {
+    using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
 
     public class InMemoryRepository<TId, TEntity> : IRepository<TId, TEntity>
     {
@@ -20,7 +23,19 @@ namespace Axle.Persistence
                 return entity;
             }
 
-            return default(TEntity);
+            return default;
+        }
+
+        public bool TryGet(TId id, out TEntity entity) => this.repo.TryGetValue(id, out entity);
+
+        public IReadOnlyList<KeyValuePair<TId, TEntity>> GetAll()
+        {
+            return this.repo.ToArray();
+        }
+
+        public IEnumerable<KeyValuePair<TId, TEntity>> Find(Func<TEntity, bool> filter)
+        {
+            return this.repo.Where(x => filter(x.Value));
         }
 
         public void Remove(TId id)

--- a/src/Axle.Persistence/RedisSessionRepository.cs
+++ b/src/Axle.Persistence/RedisSessionRepository.cs
@@ -108,12 +108,12 @@ namespace Axle.Persistence
             this.RemoveKeyIfEquals(db, accountKey, sessionId);
         }
 
-        public void RefreshSessionTimeouts(IEnumerable<Session> sessions)
+        public void RefreshSessionTimeouts(IEnumerable<int> sessions)
         {
             var db = this.multiplexer.GetDatabase();
 
             var unixNow = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-            var entriesToUpdate = sessions.Select(x => new SortedSetEntry(x.SessionId, unixNow)).ToArray();
+            var entriesToUpdate = sessions.Select(session => new SortedSetEntry(session, unixNow)).ToArray();
 
             db.SortedSetAdd(ExpirationSetKey, entriesToUpdate);
         }

--- a/src/Axle/Constants/AxleConstants.cs
+++ b/src/Axle/Constants/AxleConstants.cs
@@ -1,0 +1,11 @@
+﻿// (c) Lykke Corporation 2019 - All rights reserved. No copying, adaptation, decompiling, distribution or any other form of use permitted.
+
+namespace Axle.Constants
+{
+    using System;
+
+    public static class AxleConstants
+    {
+        public static readonly string ServiceId = Guid.NewGuid().ToString();
+    }
+}

--- a/src/Axle/Constants/RedisChannels.cs
+++ b/src/Axle/Constants/RedisChannels.cs
@@ -1,0 +1,13 @@
+﻿// (c) Lykke Corporation 2019 - All rights reserved. No copying, adaptation, decompiling, distribution or any other form of use permitted.
+
+namespace Axle.Constants
+{
+    using StackExchange.Redis;
+
+    public static class RedisChannels
+    {
+        public static readonly RedisChannel SessionTermination = "axle:notifications:termsession";
+
+        public static readonly RedisChannel OtherTabsTermination = "axle:notifications:othertabstermination";
+    }
+}

--- a/src/Axle/Controllers/ActivitiesController.cs
+++ b/src/Axle/Controllers/ActivitiesController.cs
@@ -17,12 +17,12 @@ namespace Axle.Controllers
     public class ActivitiesController : Controller
     {
         private readonly IActivityService activityService;
-        private readonly ISessionLifecycleService sessionLifecycleService;
+        private readonly ISessionService sessionService;
 
-        public ActivitiesController(IActivityService activityService, ISessionLifecycleService sessionLifecycleService)
+        public ActivitiesController(IActivityService activityService, ISessionService sessionService)
         {
             this.activityService = activityService;
-            this.sessionLifecycleService = sessionLifecycleService;
+            this.sessionService = sessionService;
         }
 
         [HttpPost("login")]
@@ -30,7 +30,7 @@ namespace Axle.Controllers
         public async Task<IActionResult> Login(string accountId)
         {
             var userName = this.User.GetUsername();
-            var sessionId = this.sessionLifecycleService.GenerateSessionId();
+            var sessionId = this.sessionService.GenerateSessionId();
 
             var activity = new SessionActivity(SessionActivityType.Login, sessionId, userName, accountId);
 

--- a/src/Axle/Controllers/SessionsController.cs
+++ b/src/Axle/Controllers/SessionsController.cs
@@ -19,17 +19,14 @@ namespace Axle.Controllers
     public class SessionsController : Controller
     {
         private readonly ISessionRepository sessionRepository;
-        private readonly IAccountsService accountsService;
-        private readonly ISessionLifecycleService sessionLifecycleService;
+        private readonly ISessionService sessionService;
 
         public SessionsController(
             ISessionRepository sessionRepository,
-            IAccountsService accountsService,
-            ISessionLifecycleService sessionLifecycleService)
+            ISessionService sessionService)
         {
             this.sessionRepository = sessionRepository;
-            this.accountsService = accountsService;
-            this.sessionLifecycleService = sessionLifecycleService;
+            this.sessionService = sessionService;
         }
 
         [Authorize(AuthorizationPolicies.System)]
@@ -54,7 +51,7 @@ namespace Axle.Controllers
         [SwaggerResponse((int)HttpStatusCode.BadRequest, typeof(TerminateSessionResponse))]
         public async Task<IActionResult> TerminateSession([BindRequired] [FromQuery] string accountId)
         {
-            var result = await this.sessionLifecycleService.TerminateSession(null, accountId, false);
+            var result = await this.sessionService.TerminateSession(null, accountId, false);
 
             if (result.Status == TerminateSessionStatus.NotFound)
             {

--- a/src/Axle/Extensions/EnumExtensions.cs
+++ b/src/Axle/Extensions/EnumExtensions.cs
@@ -2,9 +2,10 @@
 
 namespace Axle.Extensions
 {
+    using Axle.Contracts;
     using Axle.Dto;
 
-    public static class StatusCodeExtensions
+    public static class EnumExtensions
     {
         public static string ToMessage(this StatusCode code)
         {
@@ -14,6 +15,17 @@ namespace Axle.Extensions
                 case StatusCode.IF_ATH_501: return "New session created";
                 case StatusCode.IF_ATH_502: return "Existing session is killed due to concurrent login";
                 default: return "Unknown error";
+            }
+        }
+
+        public static TerminateConnectionReason ToTerminateConnectionReason(this SessionActivityType activityType)
+        {
+            switch (activityType)
+            {
+                case SessionActivityType.DifferentDeviceTermination:
+                    return TerminateConnectionReason.DifferentDevice;
+                default:
+                    return TerminateConnectionReason.Other;
             }
         }
     }

--- a/src/Axle/HostedServices/SessionExpirationService.cs
+++ b/src/Axle/HostedServices/SessionExpirationService.cs
@@ -1,0 +1,95 @@
+﻿// (c) Lykke Corporation 2019 - All rights reserved. No copying, adaptation, decompiling, distribution or any other form of use permitted.
+
+namespace Axle.HostedServices
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Axle.Contracts;
+    using Axle.Persistence;
+    using Axle.Services;
+    using Axle.Settings;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
+    using Serilog;
+
+    public sealed class SessionExpirationService : IHostedService, IDisposable
+    {
+        private readonly ISessionRepository sessionRepository;
+        private readonly ISessionService sessionLifecycleService;
+        private readonly IHubConnectionService hubConnectionService;
+        private readonly ILogger<SessionExpirationService> logger;
+        private readonly SessionSettings sessionSettings;
+
+        private Task expirationJob;
+        private CancellationTokenSource cancellationTokenSource;
+
+        public SessionExpirationService(
+            ISessionRepository sessionRepository,
+            ISessionService sessionLifecycleService,
+            IHubConnectionService hubConnectionService,
+            ILogger<SessionExpirationService> logger,
+            SessionSettings sessionSettings)
+        {
+            this.sessionRepository = sessionRepository;
+            this.sessionLifecycleService = sessionLifecycleService;
+            this.hubConnectionService = hubConnectionService;
+            this.logger = logger;
+            this.sessionSettings = sessionSettings;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            this.cancellationTokenSource?.Dispose();
+            this.cancellationTokenSource = new CancellationTokenSource();
+
+            this.expirationJob = this.RefreshTimeouts(this.cancellationTokenSource.Token);
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            this.cancellationTokenSource.Cancel();
+            return this.expirationJob;
+        }
+
+        public void Dispose()
+        {
+            this.cancellationTokenSource?.Dispose();
+            this.expirationJob?.Dispose();
+        }
+
+        private async Task RefreshTimeouts(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    try
+                    {
+                        await Task.Delay(this.sessionSettings.Timeout / 4, cancellationToken);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        break;
+                    }
+
+                    this.sessionRepository.RefreshSessionTimeouts(this.hubConnectionService.GetAllConnectedSessions());
+
+                    var sessionsToTerminate = this.sessionRepository.GetExpiredSessions();
+
+                    foreach (var session in sessionsToTerminate)
+                    {
+                        await this.sessionLifecycleService.TerminateSession(session, SessionActivityType.TimeOut);
+                        this.logger.LogInformation($"Successfully timed out session: [{session.SessionId}] for user: [{session.UserName}]");
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.Error(e, "An error occured while trying to update session timeouts");
+                }
+            }
+        }
+    }
+}

--- a/src/Axle/HostedServices/SessionTerminationListener.cs
+++ b/src/Axle/HostedServices/SessionTerminationListener.cs
@@ -1,0 +1,48 @@
+﻿// (c) Lykke Corporation 2019 - All rights reserved. No copying, adaptation, decompiling, distribution or any other form of use permitted.
+
+namespace Axle.HostedServices
+{
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Axle.Dto;
+    using Axle.Services;
+    using MessagePack;
+    using Microsoft.Extensions.Hosting;
+    using StackExchange.Redis;
+
+    public class SessionTerminationListener : IHostedService
+    {
+        private readonly ISubscriber subscriber;
+        private readonly IHubConnectionService hubConnectionService;
+
+        public SessionTerminationListener(
+            IConnectionMultiplexer multiplexer,
+            IHubConnectionService hubConnectionService)
+        {
+            this.subscriber = multiplexer.GetSubscriber();
+            this.hubConnectionService = hubConnectionService;
+        }
+
+        private static string SessionTerminationNotifs => "axle:notifications:termsession";
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return this.subscriber.SubscribeAsync(SessionTerminationNotifs, this.HandleSessionTermination);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return this.subscriber.UnsubscribeAsync(SessionTerminationNotifs, this.HandleSessionTermination);
+        }
+
+        private void HandleSessionTermination(RedisChannel channel, RedisValue value)
+        {
+            var terminateSessionNotification = MessagePackSerializer.Deserialize<TerminateSessionNotification>(value);
+
+            var connections = this.hubConnectionService.FindBySessionId(terminateSessionNotification.SessionId);
+
+            this.hubConnectionService.TerminateConnections(terminateSessionNotification.Reason, connections.ToArray());
+        }
+    }
+}

--- a/src/Axle/Services/IHubConnectionService.cs
+++ b/src/Axle/Services/IHubConnectionService.cs
@@ -4,7 +4,7 @@ namespace Axle.Services
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Axle.Contracts;
+    using Axle.Dto;
     using Microsoft.AspNetCore.SignalR;
 
     public interface IHubConnectionService
@@ -25,6 +25,8 @@ namespace Axle.Services
 
         IEnumerable<string> FindBySessionId(int sessionId);
 
-        Task TerminateConnections(SessionActivityType reason, params string[] connectionIds);
+        IEnumerable<string> FindByAccessToken(string accessToken);
+
+        Task TerminateConnections(TerminateConnectionReason reason, params string[] connectionIds);
     }
 }

--- a/src/Axle/Services/IHubConnectionService.cs
+++ b/src/Axle/Services/IHubConnectionService.cs
@@ -2,11 +2,29 @@
 
 namespace Axle.Services
 {
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Axle.Contracts;
+    using Microsoft.AspNetCore.SignalR;
 
     public interface IHubConnectionService
     {
+        Task OpenConnection(
+            HubCallerContext context,
+            string userName,
+            string accountId,
+            string clientId,
+            string accessToken,
+            bool isSupportUser);
+
+        void CloseConnection(string connectionId);
+
+        bool TryGetSessionId(string connectionId, out int sessionId);
+
+        IEnumerable<int> GetAllConnectedSessions();
+
+        IEnumerable<string> FindBySessionId(int sessionId);
+
         Task TerminateConnections(SessionActivityType reason, params string[] connectionIds);
     }
 }

--- a/src/Axle/Services/INotificationService.cs
+++ b/src/Axle/Services/INotificationService.cs
@@ -7,5 +7,7 @@ namespace Axle.Services
     public interface INotificationService
     {
         void PublishSessionTermination(TerminateSessionNotification terminateSessionNotification);
+
+        void PublishOtherTabsTermination(TerminateOtherTabsNotification terminateOtherTabsNotification);
     }
 }

--- a/src/Axle/Services/INotificationService.cs
+++ b/src/Axle/Services/INotificationService.cs
@@ -2,19 +2,10 @@
 
 namespace Axle.Services
 {
-    using System;
-    using Axle.Contracts;
     using Axle.Dto;
 
     public interface INotificationService
     {
-#pragma warning disable CA1710 // Event name should end in EventHandler
-        event Action<TerminateSessionNotification> OnSessionTerminated;
-
-        event Action<int> OnBehalfChanged;
-
         void PublishSessionTermination(TerminateSessionNotification terminateSessionNotification);
-
-        void PublishOnBehalfChange(int sessionId);
     }
 }

--- a/src/Axle/Services/ISessionService.cs
+++ b/src/Axle/Services/ISessionService.cs
@@ -5,26 +5,26 @@ namespace Axle.Services
     using System.Threading.Tasks;
     using Axle.Contracts;
     using Axle.Dto;
+    using Axle.Persistence;
 
-    public interface ISessionLifecycleService
+    public interface ISessionService
     {
-        Task OpenConnection(
-            string connectionId,
+        Task<Session> BeginSession(
             string userName,
             string accountId,
             string clientId,
             string accessToken,
             bool isSupportUser);
 
-        void CloseConnection(string connectionId);
-
-        Task<OnBehalfChangeResponse> UpdateOnBehalfState(string connectionId, string onBehalfAccount);
+        Task<OnBehalfChangeResponse> UpdateOnBehalfState(int sessionId, string onBehalfAccount);
 
         Task<TerminateSessionResponse> TerminateSession(
             string userName,
             string accountId,
             bool isSupportUser,
             SessionActivityType reason = SessionActivityType.ManualTermination);
+
+        Task TerminateSession(Session userInfo, SessionActivityType reason);
 
         int GenerateSessionId();
     }

--- a/src/Axle/Services/NotificationService.cs
+++ b/src/Axle/Services/NotificationService.cs
@@ -2,6 +2,7 @@
 
 namespace Axle.Services
 {
+    using Axle.Constants;
     using Axle.Dto;
     using MessagePack;
     using StackExchange.Redis;
@@ -15,12 +16,16 @@ namespace Axle.Services
             this.multiplexer = multiplexer;
         }
 
-        private static string SessionTerminationNotifs => "axle:notifications:termsession";
-
         public void PublishSessionTermination(TerminateSessionNotification terminateSessionNotification)
         {
             var serTerminationSessionNotif = MessagePackSerializer.Serialize(terminateSessionNotification);
-            this.multiplexer.GetDatabase().Publish(SessionTerminationNotifs, serTerminationSessionNotif);
+            this.multiplexer.GetDatabase().Publish(RedisChannels.SessionTermination, serTerminationSessionNotif);
+        }
+
+        public void PublishOtherTabsTermination(TerminateOtherTabsNotification terminateOtherTabsNotification)
+        {
+            var serializedNotif = MessagePackSerializer.Serialize(terminateOtherTabsNotification);
+            this.multiplexer.GetDatabase().Publish(RedisChannels.OtherTabsTermination, serializedNotif);
         }
     }
 }

--- a/src/Axle/Services/NotificationService.cs
+++ b/src/Axle/Services/NotificationService.cs
@@ -2,9 +2,6 @@
 
 namespace Axle.Services
 {
-    using System;
-    using System.Collections.Generic;
-    using Axle.Contracts;
     using Axle.Dto;
     using MessagePack;
     using StackExchange.Redis;
@@ -13,66 +10,17 @@ namespace Axle.Services
     {
         private readonly IConnectionMultiplexer multiplexer;
 
-        private readonly HashSet<Action<TerminateSessionNotification>> terminateSessionCallbacks = new HashSet<Action<TerminateSessionNotification>>();
-        private readonly HashSet<Action<int>> onBehalfChangeCallbacks = new HashSet<Action<int>>();
-
         public NotificationService(IConnectionMultiplexer multiplexer)
         {
             this.multiplexer = multiplexer;
-
-            var subscriber = this.multiplexer.GetSubscriber();
-
-            subscriber.Subscribe(SessionTerminationNotifs, this.HandleSessionTermination);
-            subscriber.Subscribe(OnBehalfChangeNotifs, this.HandleOnBehalfChange);
         }
-
-#pragma warning disable CA1710 // Event name should end in EventHandler
-        public event Action<TerminateSessionNotification> OnSessionTerminated
-        {
-            add { this.terminateSessionCallbacks.Add(value); }
-            remove { this.terminateSessionCallbacks.Remove(value); }
-        }
-
-        public event Action<int> OnBehalfChanged
-        {
-            add { this.onBehalfChangeCallbacks.Add(value); }
-            remove { this.onBehalfChangeCallbacks.Remove(value); }
-        }
-#pragma warning restore CA1710 // Event name should end in EventHandler
 
         private static string SessionTerminationNotifs => "axle:notifications:termsession";
-
-        private static string OnBehalfChangeNotifs => "axle:notifications:onbehalfchange";
 
         public void PublishSessionTermination(TerminateSessionNotification terminateSessionNotification)
         {
             var serTerminationSessionNotif = MessagePackSerializer.Serialize(terminateSessionNotification);
             this.multiplexer.GetDatabase().Publish(SessionTerminationNotifs, serTerminationSessionNotif);
-        }
-
-        public void PublishOnBehalfChange(int sessionId)
-        {
-            this.multiplexer.GetDatabase().Publish(OnBehalfChangeNotifs, sessionId);
-        }
-
-        private void HandleSessionTermination(RedisChannel channel, RedisValue message)
-        {
-            var result = MessagePackSerializer.Deserialize<TerminateSessionNotification>(message);
-
-            foreach (var callback in this.terminateSessionCallbacks)
-            {
-                callback(result);
-            }
-        }
-
-        private void HandleOnBehalfChange(RedisChannel channel, RedisValue value)
-        {
-            var sessionId = (int)value;
-
-            foreach (var callback in this.onBehalfChangeCallbacks)
-            {
-                callback(sessionId);
-            }
         }
     }
 }

--- a/src/Axle/Services/SessionService.cs
+++ b/src/Axle/Services/SessionService.cs
@@ -3,73 +3,42 @@
 namespace Axle.Services
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Axle.Contracts;
     using Axle.Dto;
     using Axle.Extensions;
     using Axle.Persistence;
-    using Axle.Settings;
     using Microsoft.Extensions.Logging;
-    using Serilog;
 
-    public sealed class SessionLifecycleService : ISessionLifecycleService, IDisposable
+    public sealed class SessionService : ISessionService, IDisposable
     {
         private readonly ISessionRepository sessionRepository;
         private readonly ITokenRevocationService tokenRevocationService;
         private readonly INotificationService notificationService;
         private readonly IActivityService activityService;
         private readonly IAccountsService accountsService;
-        private readonly IHubConnectionService hubConnectionService;
-        private readonly ILogger<SessionLifecycleService> logger;
-        private readonly TimeSpan sessionTimeout;
+        private readonly ILogger<SessionService> logger;
 
-        private readonly Dictionary<string, Session> connectionSessionMap = new Dictionary<string, Session>();
         private readonly SemaphoreSlim slimLock = new SemaphoreSlim(1, 1);
 
-        public SessionLifecycleService(
+        public SessionService(
             ISessionRepository sessionRepository,
             ITokenRevocationService tokenRevocationService,
             INotificationService notificationService,
             IActivityService activityService,
             IAccountsService accountsService,
-            IHubConnectionService hubConnectionService,
-            ILogger<SessionLifecycleService> logger,
-            SessionSettings sessionSettings)
+            ILogger<SessionService> logger)
         {
             this.sessionRepository = sessionRepository;
             this.tokenRevocationService = tokenRevocationService;
             this.notificationService = notificationService;
             this.activityService = activityService;
             this.accountsService = accountsService;
-            this.hubConnectionService = hubConnectionService;
             this.logger = logger;
-            this.sessionTimeout = sessionSettings.Timeout;
-
-            this.notificationService.OnSessionTerminated += this.HandleSessionTermination;
-            this.notificationService.OnBehalfChanged += this.HandleOnBehalfChange;
-
-            this.RefreshTimeouts();
         }
 
-        public void CloseConnection(string connectionId)
-        {
-            this.slimLock.Wait();
-
-            try
-            {
-                this.connectionSessionMap.Remove(connectionId);
-            }
-            finally
-            {
-                this.slimLock.Release();
-            }
-        }
-
-        public async Task OpenConnection(
-            string connectionId,
+        public async Task<Session> BeginSession(
             string userName,
             string accountId,
             string clientId,
@@ -86,8 +55,7 @@ namespace Axle.Services
 
                 if (userInfo != null && userInfo.AccessToken == accessToken)
                 {
-                    this.connectionSessionMap.TryAdd(connectionId, userInfo);
-                    return;
+                    return userInfo;
                 }
 
                 var sessionId = this.GenerateSessionId();
@@ -95,7 +63,6 @@ namespace Axle.Services
                 var newSession = new Session(userName, sessionId, accountId, accessToken, clientId, isSupportUser);
 
                 this.sessionRepository.Add(newSession);
-                this.connectionSessionMap.TryAdd(connectionId, newSession);
 
                 if (!newSession.IsSupportUser)
                 {
@@ -109,6 +76,8 @@ namespace Axle.Services
                 }
 
                 this.logger.LogWarning(StatusCode.IF_ATH_501.ToMessage());
+
+                return newSession;
             }
             finally
             {
@@ -116,15 +85,17 @@ namespace Axle.Services
             }
         }
 
-        public async Task<OnBehalfChangeResponse> UpdateOnBehalfState(string connectionId, string onBehalfAccount)
+        public async Task<OnBehalfChangeResponse> UpdateOnBehalfState(int sessionId, string onBehalfAccount)
         {
             this.slimLock.Wait();
 
             try
             {
-                if (!this.connectionSessionMap.TryGetValue(connectionId, out Session session))
+                var session = this.sessionRepository.Get(sessionId);
+
+                if (session == null)
                 {
-                    return OnBehalfChangeResponse.Fail($"Unknown connection ID [{connectionId}]");
+                    return OnBehalfChangeResponse.Fail($"Unknown session ID [{sessionId}]");
                 }
 
                 if (!session.IsSupportUser)
@@ -165,8 +136,6 @@ namespace Axle.Services
                 {
                     await this.activityService.PublishActivity(new SessionActivity(SessionActivityType.OnBehalfSupportConnected, session.SessionId, onBehalfOwner, onBehalfAccount));
                 }
-
-                this.notificationService.PublishOnBehalfChange(session.SessionId);
 
                 return OnBehalfChangeResponse.Success();
             }
@@ -256,7 +225,7 @@ namespace Axle.Services
         public int GenerateSessionId()
         {
             var rand = new Random();
-            var sessionId = 0;
+            int sessionId;
 
             do
             {
@@ -271,91 +240,6 @@ namespace Axle.Services
         {
             this.slimLock?.Dispose();
             GC.SuppressFinalize(this);
-        }
-
-        private async void RefreshTimeouts()
-        {
-            while (true)
-            {
-                try
-                {
-                    await Task.Delay(this.sessionTimeout / 4);
-
-                    await this.slimLock.WaitAsync();
-
-                    try
-                    {
-                        this.sessionRepository.RefreshSessionTimeouts(this.connectionSessionMap.Values);
-
-                        var sessionsToTerminate = this.sessionRepository.GetExpiredSessions();
-
-                        foreach (var session in sessionsToTerminate)
-                        {
-                            await this.TerminateSession(session, SessionActivityType.TimeOut);
-                            this.logger.LogInformation($"Successfully timed out session: [{session.SessionId}] for user: [{session.UserName}]");
-                        }
-                    }
-                    finally
-                    {
-                        this.slimLock.Release();
-                    }
-                }
-                catch (Exception e)
-                {
-                    Log.Error(e, "An error occured while trying to update session timeouts");
-                }
-            }
-        }
-
-        private void HandleSessionTermination(TerminateSessionNotification terminateSessionNotification)
-        {
-            this.slimLock.Wait();
-
-            try
-            {
-                // Retrieve and remove the connections to the session we're closing
-                var kvps = this.connectionSessionMap.Where(x => x.Value.SessionId == terminateSessionNotification.SessionId).ToArray();
-
-                foreach (var kvp in kvps)
-                {
-                    this.connectionSessionMap.Remove(kvp.Key);
-                }
-
-                var connections = kvps.Select(x => x.Key).ToArray();
-
-                this.hubConnectionService.TerminateConnections(terminateSessionNotification.Reason, connections);
-            }
-            finally
-            {
-                this.slimLock.Release();
-            }
-        }
-
-        private void HandleOnBehalfChange(int sessionId)
-        {
-            this.slimLock.Wait();
-
-            try
-            {
-                var session = this.sessionRepository.Get(sessionId);
-
-                if (session == null)
-                {
-                    this.logger.LogWarning($"Session with ID [{sessionId}] was not found while trying to update on behalf state");
-                    return;
-                }
-
-                var kvps = this.connectionSessionMap.Where(x => x.Value.SessionId == sessionId).ToArray();
-
-                foreach (var kvp in kvps)
-                {
-                    this.connectionSessionMap[kvp.Key] = session;
-                }
-            }
-            finally
-            {
-                this.slimLock.Release();
-            }
         }
     }
 }

--- a/src/Axle/Startup.cs
+++ b/src/Axle/Startup.cs
@@ -204,6 +204,7 @@ namespace Axle
 
             services.AddHostedService<SessionExpirationService>();
             services.AddHostedService<SessionTerminationListener>();
+            services.AddHostedService<OtherTabTerminationListener>();
 
             services.AddMemoryCache(o => o.ExpirationScanFrequency = TimeSpan.FromMinutes(1));
             services.AddDistributedMemoryCache(

--- a/src/Axle/Startup.cs
+++ b/src/Axle/Startup.cs
@@ -10,6 +10,7 @@ namespace Axle
     using Axle.Configurators;
     using Axle.Constants;
     using Axle.Contracts;
+    using Axle.HostedServices;
     using Axle.HttpClients;
     using Axle.Hubs;
     using Axle.Persistence;
@@ -134,6 +135,7 @@ namespace Axle
             var connectionRepository = new InMemoryRepository<string, HubCallerContext>();
 
             services.AddSingleton<IRepository<string, HubCallerContext>>(connectionRepository);
+            services.AddSingleton<IRepository<string, int>>(new InMemoryRepository<string, int>());
             services.AddSingleton<IReadOnlyRepository<string, HubCallerContext>>(connectionRepository);
 
             var sessionSettings = this.configuration.GetSection("SessionConfig").Get<SessionSettings>() ?? new SessionSettings();
@@ -145,7 +147,7 @@ namespace Axle
                 new RedisSessionRepository(
                     x.GetService<IConnectionMultiplexer>(),
                     sessionSettings.Timeout));
-            services.AddSingleton<ISessionLifecycleService, SessionLifecycleService>();
+            services.AddSingleton<ISessionService, SessionService>();
             services.AddSingleton<IHubConnectionService, HubConnectionService>();
             services.AddSingleton<IActivityService, ActivityService>();
 
@@ -190,7 +192,7 @@ namespace Axle
 
             services.AddSingleton<IAccountsService, AccountsService>();
 
-            services.AddSingleton<IEnumerable<SecurityGroup>>(this.configuration.GetSection("SecurityGroups").Get<IEnumerable<SecurityGroup>>());
+            services.AddSingleton(this.configuration.GetSection("SecurityGroups").Get<IEnumerable<SecurityGroup>>());
             services.AddSingleton<IUserRoleToPermissionsTransformer, UserRoleToPermissionsTransformer>();
             services.AddSingleton<IUserPermissionsClient, FakeUserPermissionsRepository>();
             services.AddSingleton<IClaimsTransformation, ClaimsTransformation>();
@@ -199,6 +201,9 @@ namespace Axle
             services.AddSingleton<IAuthorizationHandler, MobileClientAndAccountOwnerHandler>();
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddSingleton<IAccountsCache, AccountsCache>();
+
+            services.AddHostedService<SessionExpirationService>();
+            services.AddHostedService<SessionTerminationListener>();
 
             services.AddMemoryCache(o => o.ExpirationScanFrequency = TimeSpan.FromMinutes(1));
             services.AddDistributedMemoryCache(

--- a/src/Samples/Axle.Samples.SinglePageApplication/wwwroot/index.html
+++ b/src/Samples/Axle.Samples.SinglePageApplication/wwwroot/index.html
@@ -274,18 +274,9 @@
                         .configureLogging(signalR.LogLevel.Trace)
                         .build();
 
-                    connection.start().catch(function (err) {
-                        if (err.statusCode === 401) {
-                            mgr.signoutRedirect();
-                            return;
-                        }
-                        throw err.message;
-                    });
-
                     connection.onclose(function () {
-                        mgr.signoutRedirect();
                         showTokens();
-                        log("The connection was closed.");
+                        console.log("The connection was closed.");
                     });
 
                     connection.on("concurrentSessionTermination", (errorCode, errorMessage) => {
@@ -293,6 +284,18 @@
                         localStorage.setItem("errorMessage", errorMessage);
                         mgr.signoutRedirect();
                         showTokens();
+                    });
+
+                    connection.on("concurrentTabTermination", () => {
+                        log("Signing in from more than one tab is not allowed");
+                    });
+
+                    connection.start().catch(function (err) {
+                        if (err.statusCode === 401) {
+                            mgr.signoutRedirect();
+                            return;
+                        }
+                        throw err.message;
                     });
                 }
             });


### PR DESCRIPTION
Some notes on the changes:

* The session expiration timer has been moved from the session service to a hosted service
* The Redis notification listeners and handlers have also been moved from the session service to hosted services
* The connection management has been split off into a new hub connection service, clearing that responsibility from the session service
* Since the SessionLifecycleService has had its responsibility cut down to creating, updating and terminating sessions, it has been renamed to SessionService
* The connection ID -> session map has been modified to store only session IDs, thereby removing unnecessary memory usage, as the data already exists in Redis
* The service ID field is needed in order to be able to differentiate between services to help avoid terminating the new connection in the same service. It's used purely for that purpose, so it being configurable is unnecessary.